### PR TITLE
Upgrade Maven compiler version to 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <java.version>11</java.version>
   </properties>
 


### PR DESCRIPTION
This pull request makes a small update to the Java version used for compilation in the `pom.xml` file, raising it from Java 11 to Java 17. This change ensures that the project is compiled with Java 17 features and compatibility.